### PR TITLE
Use gray for descriptions and content text

### DIFF
--- a/src/components/command-view.tsx
+++ b/src/components/command-view.tsx
@@ -43,7 +43,9 @@ export const CommandView: FC<{
         </div>
         <div className="flex items-center text-lg">{command.title}</div>
       </div>
-      {command.description && <div className="pt-4">{command.description}</div>}
+      {command.description && (
+        <div className="pt-4 text-gray-400">{command.description}</div>
+      )}
       {category && (
         <div className="flex justify-end pt-2">
           <Link href={`/categories/${category.id}`}>

--- a/src/components/content-link-item.tsx
+++ b/src/components/content-link-item.tsx
@@ -8,7 +8,7 @@ export const ContentLinkItem: FC<{ title: string; link: string }> = ({
   <div className="p-2">
     <div className="transition duration-300 p-4 border-gray-900 border-2 rounded-lg mb-4 hover:border-gray-500">
       <h3 className="break-all font-bold">{title}</h3>
-      <div className="pt-4 pb-4">{children}</div>
+      <div className="pt-4 pb-4 text-gray-400">{children}</div>
       <a className="font-bold break-all" href={link}>
         {link}
       </a>


### PR DESCRIPTION
This will make the titles on commands and content items stand out a bit more and make it look less messy.