### PR TITLE
Kill the code for using CMD as meta for Mac

### DIFF
--- a/src/components/command-view.tsx
+++ b/src/components/command-view.tsx
@@ -3,7 +3,6 @@ import Link from "next/link";
 import { CategoryBox } from "./category-box";
 import { Command } from "../data/commands";
 import { categoryById } from "../data/categories";
-import { isMac } from "../utils/environment";
 
 const CommandKey: React.FC = ({ children }) => (
   <div className="text-3xl bg-white text-black pl-3 pr-3 rounded-lg mr-2">
@@ -13,7 +12,7 @@ const CommandKey: React.FC = ({ children }) => (
 
 const MetaKey: React.FC = () => (
   <>
-    <CommandKey>{isMac() ? "\u2318" : "Ctrl"}</CommandKey>
+    <CommandKey>Ctrl</CommandKey>
     <div className="text-3xl mr-2">+</div>
   </>
 );

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -1,6 +1,3 @@
 export const hasWindow = (): boolean => typeof window !== "undefined";
 
-export const isMac = (): boolean =>
-  hasWindow() && window.navigator.platform.toLowerCase().startsWith("mac");
-
 export const isOffLine = (): boolean => hasWindow() && !window.navigator.onLine;


### PR DESCRIPTION
It's wrong, it should always be Ctrl.