### PR TITLE
Change dev port and update scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,20 +20,14 @@ npm i
 npm run dev
 ```
 
+And go to [http://localhost:3000/](http://localhost:3000/)
+
+## Preview production mode
+
+```
+npm run preview
+```
+
 And go to [http://localhost:4000/](http://localhost:4000/)
 
-## Build a production bundle
-
-```
-npm run build
-```
-
-## Run in production mode
-
-First build a production bundle, then:
-
-```
-npm run start
-```
-
-And go to [http://localhost:3000/](http://localhost:3000/)
+This will build the production bundle and run the server in production mode. But it will use port 4000 so the service worker doesn't interfer with the dev mode (which runs without a service worker).

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "next dev -p 4000",
+    "dev": "next dev",
+    "preview": "next build && next start -p 4000",
     "build": "next build",
     "start": "next start",
     "lint": "eslint src",


### PR DESCRIPTION
Stop using 4000 as the dev port and 3000 as the prod port with a service worker. Since 3000 is the default port the service worker can be active for other projects.

Move dev back to 3000 and add a preview script that builds the prod bundle and starts the server at 4000 instead.